### PR TITLE
Realm support for RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ async def delete_doc(document_id):
 
 if __name__ == '__main__':
     wamp = WAMPApplication()
-    wamp.add_rpc_routes(docs_api, realm='my_application')
+    wamp.add_rpc_routes(docs_api)
 
     app = web.Application()
     app.add_routes((web.get('/', wamp.handle),))

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+plugins = trio_typing.plugin

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,3 +1,6 @@
 aiohttp>=3.0.0
+mypy==0.720
 pytest==3.7.4
+trio>=0.12.0
+trio-typing~=0.2.0
 -e .

--- a/serverwamp/adapters/asgi_asyncio.py
+++ b/serverwamp/adapters/asgi_asyncio.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Awaitable, Callable, Mapping
+from typing import Awaitable, Callable, Mapping, Set
 
 from serverwamp.adapters import asgi_base, base
 from serverwamp.protocol import WAMPProtocol
@@ -16,7 +16,7 @@ class WSTransport(asgi_base.WSTransport):
     ) -> None:
         super().__init__(asgi_scope, asgi_send)
         self._loop = loop
-        self._scheduled_tasks = set()
+        self._scheduled_tasks: Set[asyncio.Task] = set()
 
     def send_msg_soon(self, msg: str) -> None:
         task = self._loop.create_task(self.send_msg(msg))
@@ -68,7 +68,7 @@ class WAMPApplication(base.WAMPApplication):
                 msg_text = (
                     event.get('text')
                     or
-                    event.get('data').decode('utf-8')
+                    event['data'].decode('utf-8')
                 )
                 await wamp_protocol.handle_msg(msg_text)
             elif event_type == 'websocket.disconnect':

--- a/serverwamp/adapters/asgi_base.py
+++ b/serverwamp/adapters/asgi_base.py
@@ -13,6 +13,7 @@ class WSTransport(base.Transport, ABC):
     ) -> None:
         self.closed = False
         self._asgi_send = asgi_send
+        self._remote: Optional[str]
 
         cookies_header = asgi_scope['headers'].get(b'Cookie')
         if cookies_header:

--- a/serverwamp/adapters/asgi_trio.py
+++ b/serverwamp/adapters/asgi_trio.py
@@ -76,7 +76,7 @@ class WAMPApplication(base.WAMPApplication):
                     msg_text = (
                         event.get('text')
                         or
-                        event.get('data').decode('utf-8')
+                        event['data'].decode('utf-8')
                     )
                     await wamp_protocol.handle_msg(msg_text)
                 elif event_type == 'websocket.disconnect':

--- a/serverwamp/adapters/base.py
+++ b/serverwamp/adapters/base.py
@@ -1,17 +1,24 @@
+import enum
 from abc import ABC, abstractmethod
-from typing import Mapping, Optional
+from typing import Mapping, Optional, Any, Callable, Iterable
 
 from serverwamp.rpc import Router
+
+@enum.unique
+class IncidentType(enum.Enum):
+    AUTHENTICATION_FAILED = enum.auto()
+
+default_incident_uris = {
+    IncidentType.AUTHENTICATION_FAILED: 'wamp.error.not_authorized'
+}
 
 
 class Transport(ABC):
     @property
-    @abstractmethod
     def cookies(self) -> Optional[Mapping[str, str]]:
         return None
 
     @property
-    @abstractmethod
     def remote(self):
         return None
 
@@ -42,7 +49,20 @@ class WAMPApplication:
     def __init__(self, router=None, broker=None, **protocol_kwargs):
         self.router = router or Router()
         self.broker = broker
+        self.incident_uris = default_incident_uris.copy()
         self._protocol_kwargs = protocol_kwargs
 
-    def add_rpc_routes(self, routes):
-        self.router.add_routes(routes)
+    def add_default_rpc_arg(
+        self,
+        arg_name,
+        value: Optional[Any] = None,
+        factory: Optional[Callable] = None,
+        realms: Optional[Iterable[str]] = None
+    ) -> None:
+        self.router.add_default_arg(arg_name, value, factory, realms)
+
+    def add_rpc_routes(self, routes, realms=None):
+        self.router.add_routes(routes, realms)
+
+    def set_incident_uri(self, incident_type: IncidentType, uri: str):
+        self.incident_uris[incident_type] = uri

--- a/serverwamp/protocol.py
+++ b/serverwamp/protocol.py
@@ -8,8 +8,6 @@ from json import loads as deserialize
 from random import randint
 from typing import Any, Awaitable, Callable, Iterable, Optional
 
-from serverwamp.helpers import format_sockaddr
-
 logger = logging.getLogger(__name__)
 
 
@@ -87,6 +85,9 @@ class WAMPProtocol:
             {},
             'wamp.error.not_implemented'
         ))
+
+    def attach_to_real(self, realm):
+        self.session.realm = realm
 
     async def authenticate(self):
         failures = []
@@ -302,9 +303,10 @@ class WAMPProtocol:
         self.transport.send_msg_soon(serialize(msg))
 
 
-@dataclass(frozen=True)
+@dataclass()
 class WAMPSession:
     session_id: int
+    realm: Optional[str] = None
     remote: Optional[str] = None
 
 

--- a/serverwamp/rpc.py
+++ b/serverwamp/rpc.py
@@ -2,7 +2,8 @@ import inspect
 from collections import Mapping, defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, MutableMapping, Union
+from typing import (Any, Awaitable, Callable, Iterable, MutableMapping,
+                    Optional, Union)
 
 from serverwamp.helpers import camel_to_snake
 from serverwamp.protocol import (WAMPRPCErrorResponse, WAMPRPCRequest,
@@ -28,7 +29,7 @@ class Router:
         ] = defaultdict(dict)
         self.camel_snake_conversion = camel_snake_conversion
 
-    def add_route(self, uri, handler, realms=None):
+    def add_route(self, uri: str, handler, realms: Optional[Iterable[str]]=None):
         for realm in (realms or (None,)):
             self.dispatch_table[realm][uri] = handler
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2,12 +2,13 @@ import json
 import socket
 
 from serverwamp import protocol
+from serverwamp.adapters.base import Transport
 
 
 def test_publish_event():
     sent_msgs = []
 
-    class CollectingTransport:
+    class CollectingTransport(Transport):
         @staticmethod
         def get_extra_info(info_name):
             if info_name == 'peername':
@@ -15,9 +16,14 @@ def test_publish_event():
             elif info_name == 'socket':
                 return socket.socket()
 
-        @staticmethod
-        def send_msg_soon(msg):
+        def send_msg_soon(self, msg):
             sent_msgs.append(msg)
+
+        async def send_msg(self, msg: str) -> None:
+            pass
+
+        async def close(self):
+            pass
 
     proto = protocol.WAMPProtocol(transport=CollectingTransport())
 

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,5 +1,8 @@
 import asyncio
 from decimal import Decimal
+from unittest.mock import Mock
+
+import pytest
 
 from serverwamp import rpc
 from serverwamp.protocol import (WAMPRPCErrorResponse, WAMPRPCRequest,
@@ -128,3 +131,70 @@ def test_type_marshaling():
         'string_plus_suffix': 'kwargs_test_string_test_suffix',
         'decimal_plus_int': Decimal(42.0) + 45,
     }
+
+
+def test_realms():
+    route_set = rpc.RPCRouteSet()
+    router = rpc.Router()
+
+    async def any_realm_handler():
+        pass
+    any_realm_handler = Mock(wraps=any_realm_handler)
+
+    async def specific_realm_handler():
+        pass
+    specific_realm_handler = Mock(wraps=specific_realm_handler)
+
+    route_set.route(any_realm_handler)
+    router.add_route(
+        'any_realm_handler',
+        any_realm_handler
+    )
+    router.add_route(
+        'specific_realm_handler',
+        specific_realm_handler,
+        realms=('realm1',)
+    )
+
+    loop = asyncio.get_event_loop()
+
+    realm1_session = WAMPSession(1, realm='realm1')
+    realm1_specific_call = rpc.WAMPRPCRequest(
+        realm1_session,
+        1,
+        {},
+        'specific_realm_handler',
+    )
+    loop.run_until_complete(
+        router.handle_rpc_call(realm1_specific_call)
+    )
+    realm1_any_call = rpc.WAMPRPCRequest(
+        realm1_session,
+        2,
+        {},
+        'any_realm_handler',
+    )
+    loop.run_until_complete(
+        router.handle_rpc_call(realm1_any_call)
+    )
+
+    realm2_session = WAMPSession(2, realm='realm2')
+    realm2_specific_realm1_call = rpc.WAMPRPCRequest(
+        realm2_session,
+        1,
+        {},
+        'specific_realm_handler',
+    )
+    with pytest.raises(rpc.WAMPNoSuchProcedureError):
+        loop.run_until_complete(
+            router.handle_rpc_call(realm2_specific_realm1_call)
+        )
+    realm2_any_call = rpc.WAMPRPCRequest(
+        realm2_session,
+        1,
+        {},
+        'any_realm_handler',
+    )
+    loop.run_until_complete(
+        router.handle_rpc_call(realm2_any_call)
+    )

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -7,7 +7,7 @@ from serverwamp.protocol import (WAMPRPCErrorResponse, WAMPRPCRequest,
 
 
 def test_route_table():
-    route_table = rpc.RPCRouteTableDef()
+    route_table = rpc.RPCRouteSet()
 
     @route_table.route('sample.uri.1')
     async def sample_handler_1():


### PR DESCRIPTION
Realms can be specified when configuring remote procedure calls. If no realm is supplied, route is valid for any realm a session might be attached to.